### PR TITLE
update nan 

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "dependencies": {
     "async": "~0.9.0",
     "decree": "0.0.6",
-    "nan": "~1.4.1"
+    "nan": "~1.5.1"
   },
   "scripts": {
     "install": "node-gyp rebuild",


### PR DESCRIPTION
This updates nan to at least version 1.5.1, enabling compatibility with io.js 1.0.1

All tests pass.