### PR TITLE
update nan to work with io.js 2.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "dependencies": {
     "async": "~0.9.0",
     "decree": "0.0.6",
-    "nan": "~1.7.0"
+    "nan": "^1.8.4"
   },
   "scripts": {
     "install": "node-gyp rebuild",


### PR DESCRIPTION
Fixes this error:

```
../node_modules/nan/nan.h:207:68: error: too many arguments to function call, expected at most 2, have 4
    return v8::Signature::New(v8::Isolate::GetCurrent(), receiver, argc, argv);
           ~~~~~~~~~~~~~~~~~~                                      ^~~~~~~~~~
```