### PR TITLE
update nan to 1.8.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "dependencies": {
     "async": "~0.9.0",
     "decree": "0.0.6",
-    "nan": "~1.7.0"
+    "nan": "~1.8.4"
   },
   "scripts": {
     "install": "node-gyp rebuild",


### PR DESCRIPTION
Installing this package fails on io.js because io.js uses a more recent version of v8 which changes Signature::New. (seen on [nan issue 308](https://github.com/nodejs/nan/issues/308)).

Updating nan to 1.8.4 fixes this issue, and `npm test` runs fine.

Tested on Node 0.12.2 and io.js 2.0.1 .