### PR TITLE
Use bindings package when requiring node bindingins. Fixes #242

### DIFF
--- a/lib/Image.js
+++ b/lib/Image.js
@@ -1,6 +1,6 @@
 (function(undefined) {
 
-    var lwip_image = require('../build/Release/lwip_image');
+    var lwip_image = require('bindings')('lwip_image');
 
     function Image(pixelsBuf, width, height, trans, metadata) {
         this.__lwip = new lwip_image.LwipImage(pixelsBuf, width, height);

--- a/lib/ImagePrototypeInit.js
+++ b/lib/ImagePrototypeInit.js
@@ -6,8 +6,8 @@
         decree = require('decree'),
         defs = require('./defs'),
         util = require('./util'),
-        encoder = require('../build/Release/lwip_encoder'),
-        lwip_image = require('../build/Release/lwip_image'),
+        encoder = require('bindings')('lwip_encoder'),
+        lwip_image = require('bindings')('lwip_image'),
         normalizeColor = util.normalizeColor;
 
     var judges = {

--- a/lib/obtain.js
+++ b/lib/obtain.js
@@ -5,7 +5,7 @@
         decree = require('decree'),
         defs = require('./defs'),
         util = require('./util'),
-        decoder = require('../build/Release/lwip_decoder'),
+        decoder = require('bindings')('lwip_decoder'),
         Image = require('./Image');
 
     var openers = [{

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "main": "index.js",
   "dependencies": {
     "async": "~0.9.0",
+    "bindings": "^1.2.1",
     "decree": "0.0.6",
     "nan": "~2.0.9"
   },


### PR DESCRIPTION
node-gyp uses node build configuration when building addons.

Because lwip was looking only in `build/Release` folder
it wasn't working when installed on a debug build of node.

node-bindings solves this issue, it will look in all possible places
where the bindings can be.