### PR TITLE
Updates nan version to ^2.3.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "dependencies": {
     "async": "~0.9.0",
     "decree": "0.0.6",
-    "nan": "~2.0.9"
+    "nan": "^2.3.2"
   },
   "scripts": {
     "install": "node-gyp rebuild",


### PR DESCRIPTION
This change updates `lwip` to the latest version of `nan` in order to fix an issue with node v6 (#249).

`nan` v2.0.9 uses v8 methods which are no longer available in node6. [Version 2.2.0 fixed this issue](https://github.com/nodejs/nan/commit/3603435109f981606d300eb88004ca101283acec), so now those methods are only utilized for older versions of node.

All tests pass and the build successfully works in node v6.0.0 on Mac OS X 10.11.4.